### PR TITLE
Added new popover component.

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,6 +15,8 @@ jQuery(document).ready(function() {
   // Tooltips
   jQuery('.bs-wrap-tooltip').tooltip();
 
+  // Popovers
+  jQuery('.bs-wrap-popover').popover();
 
   // Images
   jQuery('.bs-wrap-image').each(function() {

--- a/syntax/popover.php
+++ b/syntax/popover.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Bootstrap Wrapper Plugin: Tooltip
+ * 
+ * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
+ * @author     Jos Roossien <mail@jroossien.com>
+ * @copyright  (C) 2015, Giuseppe Di Terlizzi
+ */
+ 
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+require_once(dirname(__FILE__).'/bootstrap.php');
+
+class syntax_plugin_bootswrapper_popover extends syntax_plugin_bootswrapper_bootstrap {
+
+    protected $pattern_start  = '<popover.*?>(?=.*?</popover>)';
+    protected $pattern_end    = '</popover>';
+    protected $tag_attributes = array(
+
+      'placement' => array('type'     => 'string',
+                           'values'   => array('top', 'bottom', 'left', 'right', 'auto'),
+                           'required' => true,
+                           'default'  => 'top'),
+
+      'title'     => array('type'     => 'string',
+                           'values'   => null,
+                           'required' => false,
+                           'default'  => null),
+
+      'content'   => array('type'     => 'string',
+                           'values'   => null,
+                           'required' => true,
+                           'default'  => null),
+
+      'trigger'   => array('type'     => 'string',
+                           'values'   => array('click', 'hover', 'focus'),
+                           'required' => true,
+                           'default'  => 'click'),
+
+      'html'      => array('type'     => 'boolean',
+                           'values'   => array(0, 1),
+                           'required' => false,
+                           'default'  => false),
+
+    );
+
+    function getPType() { return 'normal';}
+
+    function render($mode, Doku_Renderer $renderer, $data) {
+
+        if (empty($data)) return false;
+
+        if ($mode == 'xhtml') {
+
+            /** @var Doku_Renderer_xhtml $renderer */
+            list($state, $match, $attributes) = $data;
+
+            switch($state) {
+
+                case DOKU_LEXER_ENTER:
+
+                    $placement = $attributes['placement'];
+                    $title     = $attributes['title'];
+                    $content   = $attributes['content'];
+                    $trigger   = $attributes['trigger'];
+                    $html      = $attributes['html'];
+
+                    if ($html) {
+                      $title = hsc(p_render('xhtml',p_get_instructions($title), $info));
+                      $content = hsc(p_render('xhtml',p_get_instructions($content), $info));
+                    }
+
+                    $markup = sprintf('<span class="bs-wrap bs-wrap-popover" data-toggle="popover" data-trigger="%s" data-html="%s" data-placement="%s" title="%s" data-content="%s">',
+                        $trigger, $html, $placement, $title, $content);
+
+                    $renderer->doc .= $markup;
+                    return true;
+
+                case DOKU_LEXER_EXIT:
+                    $renderer->doc .= '</span>';
+                    return true;
+
+            }
+
+            return true;
+
+        }
+
+        return false;
+
+    }
+
+}


### PR DESCRIPTION
Added a new popover component.
It can be used on pretty much any content like text, buttons, labels etc.
It supports click, hover and focus triggers and all the other attributes similar to tooltip.
You can see it in action here: http://gameboxx.info/wiki/bootstrap/popover

It might be a good idea to add the link to my bootsrap documentation on your plugin page btw.
It's up to date, open for anyone to edit and has a bit more in depth details about certain things.
And it's much easier to navigate in my opinion with the tabs.
http://gameboxx.info/wiki/bootstrap