### PR TITLE
Added styling attributes for all components. class, id and style.

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -6,3 +6,4 @@
  */
 
 $conf['loadBootstrap'] = 0;
+$conf['allowStylingAttributes'] = 0;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -6,3 +6,4 @@
  */
 
 $meta['loadBootstrap'] = array('onoff', '_caution' => 'danger');
+$meta['allowStylingAttributes'] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,3 +8,4 @@
  
 // for the configuration manager
 $lang['loadBootstrap'] = "Load the Bootstrap vanilla CSS. Disable it if you have installed a Bootstrap based template.";
+$lang['allowStylingAttributes'] = "Allow the use of ''class=\"\"'', ''id=\"\"'' and ''style=\"\"'' attributes on all components.";

--- a/lang/ja/settings.php
+++ b/lang/ja/settings.php
@@ -7,3 +7,4 @@
  
 // 設定管理画面用
 $lang['loadBootstrap'] = "Bootstrap vanilla CSS を読み込む。Bootstrap を基にしたテンプレートをインストールした場合、無効にします。";
+$lang['allowStylingAttributes'] = "Allow the use of ''class=\"\"'', ''id=\"\"'' and ''style=\"\"'' attributes on all components.";

--- a/script.js
+++ b/script.js
@@ -122,6 +122,14 @@ jQuery(document).ready(function() {
         case 'btnSize':
           btn_class.push(['btn-', value].join(''));
           break;
+        case 'btnClass':
+          btn_class.push(value);
+        case 'btnId':
+          $btn_link.attr('id', value);
+          break;
+        case 'btnStyle':
+          $btn_link.attr('style', value);
+          break;
         case 'btnBlock':
           btn_class.push('btn-block');
           break;

--- a/syntax/accordion.php
+++ b/syntax/accordion.php
@@ -14,7 +14,7 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_accordion extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start  = '<accordion>';
+    protected $pattern_start  = '<accordion.*?>(?=.*?</accordion>)';
     protected $pattern_end    = '</accordion>';
 
     protected $tag_attributes = array(
@@ -42,7 +42,10 @@ class syntax_plugin_bootswrapper_accordion extends syntax_plugin_bootswrapper_bo
                 case DOKU_LEXER_ENTER:
 
                     $id     = $attributes['id'];
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-accordion panel-group" id="%s">', $id);
+                    $style = $this->getStylingAttributes($attributes);
+
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-accordion panel-group %s" id="%s" style="%s">',
+                      $style['class'], $id, $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/affix.php
+++ b/syntax/affix.php
@@ -55,6 +55,7 @@ class syntax_plugin_bootswrapper_affix extends syntax_plugin_bootswrapper_bootst
                     $top    = $attributes['offset-top'];
                     $bottom = $attributes['offset-bottom'];
                     $target = $attributes['target'];
+                    $style = $this->getStylingAttributes($attributes);
                     $data   = array();
 
                     if ($top) {
@@ -67,7 +68,8 @@ class syntax_plugin_bootswrapper_affix extends syntax_plugin_bootswrapper_bootst
                         $data[] = sprintf('data-target="%s"', $target);
                     }
 
-                    $markup = sprintf('<div style="z-index:1024" class="bs-wrap bs-wrap-affix" data-spy="affix" %s>', implode(' ', $data));
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-affix %s" id="%s" style="z-index:1024; %s" data-spy="affix" %s>',
+                      $style['class'], $style['id'], $style['style'], implode(' ', data));
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/alert.php
+++ b/syntax/alert.php
@@ -50,9 +50,11 @@ class syntax_plugin_bootswrapper_alert extends syntax_plugin_bootswrapper_bootst
                 case DOKU_LEXER_ENTER:
 
                     extract($attributes);
+                    $style = $this->getStylingAttributes($attributes);
+                    print_r($style);
 
-                    $markup = sprintf('<div class="bs-wrap alert alert-%s %s" role="alert">',
-                                      $type, (($dismiss) ? 'alert-dismissible' : ''));
+                    $markup = sprintf('<div class="bs-wrap alert alert-%s %s %s" id="%s" style="%s" role="alert">',
+                      $type, (($dismiss) ? 'alert-dismissible' : ''), $style['class'], $style['id'], $style['style']);
 
                     if ($dismiss) {
                         $markup .= '<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>';

--- a/syntax/alert.php
+++ b/syntax/alert.php
@@ -51,7 +51,6 @@ class syntax_plugin_bootswrapper_alert extends syntax_plugin_bootswrapper_bootst
 
                     extract($attributes);
                     $style = $this->getStylingAttributes($attributes);
-                    print_r($style);
 
                     $markup = sprintf('<div class="bs-wrap alert alert-%s %s %s" id="%s" style="%s" role="alert">',
                       $type, (($dismiss) ? 'alert-dismissible' : ''), $style['class'], $style['id'], $style['style']);

--- a/syntax/badge.php
+++ b/syntax/badge.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_badge extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<badge>';
-    protected $pattern_end   = '</badge>';
+    protected $pattern_start  = '<badge.*?>(?=.*?</badge>)';
+    protected $pattern_end    = '</badge>';
 
-    protected $template_start = '<span class="bs-wrap bs-wrap-badge badge">';
+    protected $template_start = '<span class="bs-wrap bs-wrap-badge badge %s" id="%s" style="%s">';
     protected $template_end   = '</span>';
 
     function getPType() { return 'normal';}

--- a/syntax/bootstrap.php
+++ b/syntax/bootstrap.php
@@ -19,7 +19,7 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
   protected $template_end     = '</div>';
   protected $header_pattern   = '[ \t]*={2,}[^\n]+={2,}[ \t]*(?=\n)';
   protected $tag_attributes   = array();
-  protected $core_tag_attributes = array(
+  protected $styling_attributes = array(
 
     'style' => array('type'  => 'string',
                   'values'   => null,
@@ -48,7 +48,7 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
     global $ACT;
 
     if ($this->getConf('allowStylingAttributes')) {
-      $all_attributes  = array_merge($this->tag_attributes, $this->core_tag_attributes);
+      $all_attributes  = array_merge($this->tag_attributes, $this->styling_attributes);
     } else {
       $all_attributes  = $this->tag_attributes;
     }
@@ -133,26 +133,36 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
    * @return The markup passed in with styling parsed.
    */
   function parseMarkupSyntax($markup, $attributes = array()) {
-    if ($this->getConf('allowStylingAttributes')) {
-      $class    = $attributes['class'];
-      $id       = $attributes['id'];
-      $style    = $attributes['style'];
+    $styling = $this->getStylingAttributes($attributes);
 
-      if (strpos($markup, 'class=') === false) {
-        $class = 'class="' . $class . '"';
-      }
-      if (strpos($markup, 'id=') === false) {
-        $id = ''; //There can only be one ID
-      }
-      if (strpos($markup, 'style=') === false) {
-        $style = 'style="' . $style . '"';
-      }
-
-      $markup = sprintf($markup, $class, $id, $style);
-    } else {
-      $markup = sprintf($markup, '', '', '');
+    if (strpos($markup, 'class=') === false) {
+      $styling['class'] = 'class="' . $styling['class'] . '"';
     }
+    if (strpos($markup, 'id=') === false) {
+      $styling['id'] = ''; //There can only be one ID
+    }
+    if (strpos($markup, 'style=') === false) {
+      $styling['style'] = 'style="' . $styling['style'] . '"';
+    }
+
+    $markup = sprintf($markup, $styling['class'], $styling['id'], $styling['style']);
     return $markup;
+  }
+
+  /**
+   * Get array with styling attributes from the attributes array passed in.
+   * If the user has styling disabled this array will contain empty strings.
+   * @param array $attributes The attribute array with user values.
+   * @return array The array with styling attribute values or empty string.
+   */
+  function getStylingAttributes($attributes = array()) {
+    $styling = array('class' => '', 'id' => '', 'style' => '');
+    if ($this->getConf('allowStylingAttributes')) {
+      $styling['class'] = $attributes['class'];
+      $styling['class'] = $attributes['id'];
+      $styling['class'] = $attributes['style'];
+    }
+    return $styling;
   }
 
 

--- a/syntax/bootstrap.php
+++ b/syntax/bootstrap.php
@@ -159,8 +159,8 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
     $styling = array('class' => '', 'id' => '', 'style' => '');
     if ($this->getConf('allowStylingAttributes')) {
       $styling['class'] = $attributes['class'];
-      $styling['class'] = $attributes['id'];
-      $styling['class'] = $attributes['style'];
+      $styling['id'] = $attributes['id'];
+      $styling['style'] = $attributes['style'];
     }
     return $styling;
   }

--- a/syntax/bootstrap.php
+++ b/syntax/bootstrap.php
@@ -123,45 +123,27 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
   }
 
   /**
-   * This function replaces placeholders in the specified markup with styling attribute values from the user.
-   * It will only do this if the user has allowed styling attributes in the config.
-   * The markup string should contain three %s placeholders.
-   * If the markup already has styling or a class you can put the placeholder within the brackets.
-   * For example: <div class="bs-wrap %s" %s %s></div> or if it doesn't have a class you'd use <div %s %s %s></div>
-   * @param $markup Html markup element containting placeholders for the styling attributes.
-   * @param array $attributes Attribute values from user.
-   * @return The markup passed in with styling parsed.
-   */
-  function parseMarkupSyntax($markup, $attributes = array()) {
-    $styling = $this->getStylingAttributes($attributes);
-
-    if (strpos($markup, 'class=') === false) {
-      $styling['class'] = 'class="' . $styling['class'] . '"';
-    }
-    if (strpos($markup, 'id=') === false) {
-      $styling['id'] = ''; //There can only be one ID
-    }
-    if (strpos($markup, 'style=') === false) {
-      $styling['style'] = 'style="' . $styling['style'] . '"';
-    }
-
-    $markup = sprintf($markup, $styling['class'], $styling['id'], $styling['style']);
-    return $markup;
-  }
-
-  /**
    * Get array with styling attributes from the attributes array passed in.
    * If the user has styling disabled this array will contain empty strings.
    * @param array $attributes The attribute array with user values.
    * @return array The array with styling attribute values or empty string.
    */
-  function getStylingAttributes($attributes = array()) {
-    $styling = array('class' => '', 'id' => '', 'style' => '');
+  function getStylingAttributes($attributes) {
+    $styling = array(
+      'class' => '',
+      'id' => '',
+      'style' => ''
+    );
+
     if ($this->getConf('allowStylingAttributes')) {
-      $styling['class'] = $attributes['class'];
-      $styling['id'] = $attributes['id'];
-      $styling['style'] = $attributes['style'];
+      if (isset($attributes['class']) && $attributes['class'])
+        $styling['class'] = $attributes['class'];
+      if (isset($attributes['id']) && $attributes['id'])
+        $styling['id'] = $attributes['id'];
+      if (isset($attributes['style']) && $attributes['style'])
+        $styling['style'] = $attributes['style'];
     }
+
     return $styling;
   }
 
@@ -259,7 +241,9 @@ class syntax_plugin_bootswrapper_bootstrap extends DokuWiki_Syntax_Plugin {
     switch($state) {
 
       case DOKU_LEXER_ENTER:
-        $markup = $this->parseMarkupSyntax($this->template_start, $attributes);
+        $style = $this->getStylingAttributes($attributes);
+
+        $markup = sprintf($this->template_start, $style['class'], $style['id'], $style['style']);
         $renderer->doc .= $markup;
         return true;
 

--- a/syntax/button.php
+++ b/syntax/button.php
@@ -60,6 +60,7 @@ class syntax_plugin_bootswrapper_button extends syntax_plugin_bootswrapper_boots
 
                 case DOKU_LEXER_ENTER:
 
+                    $style = $this->getStylingAttributes($attributes);
                     $html5data = array();
 
                     foreach ($attributes as $key => $value) {

--- a/syntax/callout.php
+++ b/syntax/callout.php
@@ -45,8 +45,10 @@ class syntax_plugin_bootswrapper_callout extends syntax_plugin_bootswrapper_boot
                 case DOKU_LEXER_ENTER:
 
                     $type = $attributes['type'];
+                    $style = $this->getStylingAttributes($attributes);
 
-                    $markup = sprintf('<div class="bs-wrap bs-callout bs-callout-%s">', $type);
+                    $markup = sprintf('<div class="bs-wrap bs-callout bs-callout-%s %s" id="%s" style="%s">',
+                      $type, $style['class'], $style['id'], $style['style']);
 
                     if ($title = $attributes['title']) {
                       $markup .= "<h4>$title</h4>";

--- a/syntax/caption.php
+++ b/syntax/caption.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_caption extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<caption>';
+    protected $pattern_start = '<caption.*?>(?=.*?</caption>)';
     protected $pattern_end   = '</caption>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-caption caption">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-caption caption %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType() { return 'block';}

--- a/syntax/carousel.php
+++ b/syntax/carousel.php
@@ -54,13 +54,15 @@ class syntax_plugin_bootswrapper_carousel extends syntax_plugin_bootswrapper_boo
 
                 case DOKU_LEXER_ENTER:
 
+                    $style = $this->getStylingAttributes($attributes);
                     $html5_attributes = array();
 
                     foreach ($attributes as $attribute => $value) {
                       $html5_attributes[] = sprintf('data-%s="%s"', $attribute, $value);
                     }
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-carousel carousel slide" data-ride="carousel" %s><ol class="carousel-indicators"></ol><div class="carousel-inner" role="listbox">', implode(' ', $html5_attributes));
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-carousel carousel slide %s" data-ride="carousel" id="%s" style="%s" %s><ol class="carousel-indicators"></ol><div class="carousel-inner" role="listbox">',
+                      $style['class'], $style['id'], $style['style'], implode(' ', $html5_attributes));
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/collapse.php
+++ b/syntax/collapse.php
@@ -48,7 +48,10 @@ class syntax_plugin_bootswrapper_collapse extends syntax_plugin_bootswrapper_boo
 
                     $id        = $attributes['id'];
                     $collapsed = $attributes['collapsed'];
-                    $markup    = sprintf('<div class="bs-wrap bs-wrap-collapse collapse %s" id="%s">', ($collapsed ? '' : 'in'), $id);
+                    $style = $this->getStylingAttributes($attributes);
+
+                    $markup    = sprintf('<div class="bs-wrap bs-wrap-collapse collapse %s %s" id="%s" style="%s">',
+                      ($collapsed ? '' : 'in'), $style['class'], $id, $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/column.php
+++ b/syntax/column.php
@@ -55,13 +55,15 @@ class syntax_plugin_bootswrapper_column extends syntax_plugin_bootswrapper_boots
 
                 case DOKU_LEXER_ENTER:
 
+                    $style = $this->getStylingAttributes($attributes);
                     $col = '';
 
                     foreach (array('lg', 'md', 'sm', 'xs') as $device) {
                         $col .= isset($attributes[$device]) ? sprintf('col-%s-%s ', $device, $attributes[$device]) : '';
                     }
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-col %s">', trim($col));
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-col %s %s" id="%s" style="%s">',
+                      trim($col), $style['class'], $style['id'], $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/grid.php
+++ b/syntax/grid.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_grid extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<grid>';
+    protected $pattern_start = '<grid.*?>(?=.*?</grid>)';
     protected $pattern_end   = '</grid>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-row row">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-row row %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/hidden.php
+++ b/syntax/hidden.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_hidden extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<hidden>';
+    protected $pattern_start = '<hidden.*?>(?=.*?</hidden>)';
     protected $pattern_end   = '</hidden>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-hidden hidden">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-hidden hidden %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/image.php
+++ b/syntax/image.php
@@ -40,13 +40,15 @@ class syntax_plugin_bootswrapper_image extends syntax_plugin_bootswrapper_bootst
 
                     extract($attributes);
 
+                    $style = $this->getStylingAttributes($attributes);
                     $html5_data = array();
 
                     if ($shape) {
                         $html5_data[] = sprintf('data-img-shape="%s"', $shape);
                     }
 
-                    $markup = sprintf('<span class="bs-wrap bs-wrap-image" %s>', implode(' ', $html5_data));
+                    $markup = sprintf('<span class="bs-wrap bs-wrap-image %s" id="%s" style="%s" %s>',
+                      $style['class'], $style['id'], $style['style'], implode(' ', $html5_data));
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/invisible.php
+++ b/syntax/invisible.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_invisible extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<invisible>';
+    protected $pattern_start = '<invisible.*?>(?=.*?</invisible>)';
     protected $pattern_end   = '</invisible>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-invisible invisible">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-invisible invisible %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/jumbotron.php
+++ b/syntax/jumbotron.php
@@ -45,6 +45,7 @@ class syntax_plugin_bootswrapper_jumbotron extends syntax_plugin_bootswrapper_bo
 
                     $background = $attributes['background'];
                     $color      = $attributes['color'];
+                    $style = $this->getStylingAttributes($attributes);
 
                     $styles = array();
 
@@ -56,7 +57,8 @@ class syntax_plugin_bootswrapper_jumbotron extends syntax_plugin_bootswrapper_bo
                       $styles[] = sprintf('color:%s', hsc($color));
                     }
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-jumbotron jumbotron" style="%s">', implode(';', $styles), $type);
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-jumbotron jumbotron %s" id="%s" style="%s %s">',
+                      $style['class'], $style['id'], (implode(';', $styles) . ';'), $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/label.php
+++ b/syntax/label.php
@@ -50,8 +50,10 @@ class syntax_plugin_bootswrapper_label extends syntax_plugin_bootswrapper_bootst
                     $label_tag = (($is_block) ? 'div' : 'span');
                     $type      = $attributes['type'];
                     $icon      = $attributes['icon'];
+                    $style = $this->getStylingAttributes($attributes);
 
-                    $markup = sprintf('<%s class="bs-wrap bs-wrap-label label label-%s">', $label_tag, $type);
+                    $markup = sprintf('<%s class="bs-wrap bs-wrap-label label label-%s %s" id="%s" style="%s">',
+                      $label_tag, $type, $style['class'], $style['id'], $style['style']);
 
                     if ($icon) {
                       $markup .= sprintf('<i class="%s"></i> ', $icon);

--- a/syntax/lead.php
+++ b/syntax/lead.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_lead extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<lead>';
+    protected $pattern_start = '<lead.*?>(?=.*?</lead>)';
     protected $pattern_end   = '</lead>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-lead lead">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-lead lead %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_list extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<list-group>';
+    protected $pattern_start = '<list-group.*?>(?=.*?</list-group>)';
     protected $pattern_end   = '</list-group>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-list-group">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-list-group %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType() { return 'block';}

--- a/syntax/modal.php
+++ b/syntax/modal.php
@@ -83,10 +83,11 @@ class syntax_plugin_bootswrapper_modal extends syntax_plugin_bootswrapper_bootst
           $show     = $attributes['show'];
           $fade     = $attributes['fade'] === true ? 'fade' : '';
           $backdrop = $attributes['backdrop'];
+          $style = $this->getStylingAttributes($attributes);
 
           //Modal
-          $markup = sprintf('<div class="bs-wrap bs-wrap-modal modal %s" id="%s" role="dialog" tabindex="-1" aria-labelledby="%s" data-show="%s" data-backdrop="%s" data-keyboard="%s">',
-            $fade, $id, $title, $show, $backdrop, $keyboard);
+          $markup = sprintf('<div class="bs-wrap bs-wrap-modal modal %s %s" id="%s" style="%s" role="dialog" tabindex="-1" aria-labelledby="%s" data-show="%s" data-backdrop="%s" data-keyboard="%s">',
+            $fade, $style['class'], $id, $style['style'], $title, $show, $backdrop, $keyboard);
           $markup .= sprintf('<div class="bs-wrap modal-dialog modal-%s" role="document"><div class="bs-wrap modal-content">', $size);
 
           //Header/Title

--- a/syntax/nav.php
+++ b/syntax/nav.php
@@ -56,6 +56,7 @@ class syntax_plugin_bootswrapper_nav extends syntax_plugin_bootswrapper_bootstra
 
                 case DOKU_LEXER_ENTER:
 
+                    $style = $this->getStylingAttributes($attributes);
                     $html5data  = array();
 
                     if (! empty($this->type)) {
@@ -66,7 +67,8 @@ class syntax_plugin_bootswrapper_nav extends syntax_plugin_bootswrapper_bootstra
                         $html5data[] = sprintf('data-nav-%s="%s"', $key, $value);
                     }
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-nav" %s>', implode(' ', $html5data));
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-nav %s" id="%s" style="%s" %s>',
+                      $style['class'], $style['id'], $style['style'], implode(' ', $html5data));
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/pageheader.php
+++ b/syntax/pageheader.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_pageheader extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<page-header>';
+    protected $pattern_start = '<page-header.*?>(?=.*?</page-header>)';
     protected $pattern_end   = '</page-header>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-page-header page-header">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-page-header page-header %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
 }

--- a/syntax/pane.php
+++ b/syntax/pane.php
@@ -41,7 +41,10 @@ class syntax_plugin_bootswrapper_pane extends syntax_plugin_bootswrapper_bootstr
                 case DOKU_LEXER_ENTER:
 
                     $id     = $attributes['id'];
-                    $markup = sprintf('<div role="tabpanel" class="bs-wrap bs-wrap-tab-pane tab-pane" id="%s">', $id);
+                    $style = $this->getStylingAttributes($attributes);
+
+                    $markup = sprintf('<div role="tabpanel" class="bs-wrap bs-wrap-tab-pane tab-pane %s" id="%s" style="%s">',
+                      $style['class'], $id, $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/panel.php
+++ b/syntax/panel.php
@@ -72,8 +72,10 @@ class syntax_plugin_bootswrapper_panel extends syntax_plugin_bootswrapper_bootst
                     $subtitle = $attributes['subtitle'];
                     $icon     = $attributes['icon'];
                     $nobody   = $attributes['no-body'];
+                    $style = $this->getStylingAttributes($attributes);
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-panel panel panel-%s">', $type);
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-panel panel panel-%s %s" id="%s" style="%s">',
+                      $type, $style['class'], $style['id'], $style['style']);
 
                     if ($title || $subtitle) {
 

--- a/syntax/panelbody.php
+++ b/syntax/panelbody.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_panelbody extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<panel-body>';
+    protected $pattern_start = '<panel-body.*?>(?=.*?</panel-body>)';
     protected $pattern_end   = '</panel-body>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-panel-body panel-body">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-panel-body panel-body %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/popover.php
+++ b/syntax/popover.php
@@ -65,14 +65,15 @@ class syntax_plugin_bootswrapper_popover extends syntax_plugin_bootswrapper_boot
                     $content   = $attributes['content'];
                     $trigger   = $attributes['trigger'];
                     $html      = $attributes['html'];
+                    $style = $this->getStylingAttributes($attributes);
 
                     if ($html) {
                       $title = hsc(p_render('xhtml',p_get_instructions($title), $info));
                       $content = hsc(p_render('xhtml',p_get_instructions($content), $info));
                     }
 
-                    $markup = sprintf('<span class="bs-wrap bs-wrap-popover" data-toggle="popover" data-trigger="%s" data-html="%s" data-placement="%s" title="%s" data-content="%s">',
-                        $trigger, $html, $placement, $title, $content);
+                    $markup = sprintf('<span class="bs-wrap bs-wrap-popover %s" id="%s" style="%s" data-toggle="popover" data-trigger="%s" data-html="%s" data-placement="%s" title="%s" data-content="%s">',
+                      $style['class'], $style['id'], $style['style'], $trigger, $html, $placement, $title, $content);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/progress.php
+++ b/syntax/progress.php
@@ -15,10 +15,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_progress extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start  = '<progress>';
+    protected $pattern_start  = '<progress.*?>(?=.*?</progress>)';
     protected $pattern_end    = '</progress>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-progress progress">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-progress progress %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
 }

--- a/syntax/progressbar.php
+++ b/syntax/progressbar.php
@@ -61,6 +61,7 @@ class syntax_plugin_bootswrapper_progressbar extends syntax_plugin_bootswrapper_
                 case DOKU_LEXER_ENTER:
 
                     extract($attributes);
+                    $style = $this->getStylingAttributes($attributes);
 
                     $classCode = "";
 
@@ -72,8 +73,8 @@ class syntax_plugin_bootswrapper_progressbar extends syntax_plugin_bootswrapper_
                         $classCode .= " active";
                     }
 
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-progress-bar progress-bar progress-bar-%s %s" role="progressbar" aria-valuenow="%s" aria-valuemin="0" aria-valuemax="100" style="width: %s%%;%s">',
-                                      $type, $classCode, $value, $value, ($showvalue ? 'min-width: 2em;' : ''));
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-progress-bar progress-bar progress-bar-%s %s %s" id="%s" role="progressbar" aria-valuenow="%s" aria-valuemin="0" aria-valuemax="100" style="width: %s%%;%s %s">',
+                                      $type, $classCode, $style['class'], $style['id'], $value, $value, ($showvalue ? 'min-width: 2em;' : ''), $style['style']);
 
                     if ($showvalue){
                         $markup .= sprintf('%s%% ', $value);

--- a/syntax/row.php
+++ b/syntax/row.php
@@ -14,7 +14,7 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_row extends syntax_plugin_bootswrapper_grid {
 
-    protected $pattern_start = '<row>';
+    protected $pattern_start = '<row.*?>(?=.*?</row>)';
     protected $pattern_end   = '</row>';
 
 }

--- a/syntax/show.php
+++ b/syntax/show.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_show extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<show>';
+    protected $pattern_start = '<show.*?>(?=.*?</show>)';
     protected $pattern_end   = '</show>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-show show">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-show show %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/slide.php
+++ b/syntax/slide.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_slide extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<slide>';
+    protected $pattern_start = '<slide.*?>(?=.*?</slide>)';
     protected $pattern_end   = '</slide>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-slide item">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-slide item %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/text.php
+++ b/syntax/text.php
@@ -68,6 +68,7 @@ class syntax_plugin_bootswrapper_text extends syntax_plugin_bootswrapper_bootstr
           $background = $attributes['background'];
           $align      = $attributes['align'];
           $transform  = $attributes['transform'];
+          $style = $this->getStylingAttributes($attributes);
 
           $classes = array();
           $styles  = array();
@@ -87,10 +88,8 @@ class syntax_plugin_bootswrapper_text extends syntax_plugin_bootswrapper_bootstr
 
           }
 
-          $markup = sprintf('<%s class="bs-wrap bs-wrap-text text %s" style="%s">',
-                            $text_tag,
-                            implode(' ', $classes),
-                            implode(';', $styles));
+          $markup = sprintf('<%s class="bs-wrap bs-wrap-text text %s %s" id="%s" style="%s %s">',
+                            $text_tag, implode(' ', $classes), $style['class'], $style['id'], implode(';', $styles) . ';', $style['style']);
 
           $renderer->doc .= $markup;
           return true;

--- a/syntax/thumbnail.php
+++ b/syntax/thumbnail.php
@@ -14,10 +14,10 @@ require_once(dirname(__FILE__).'/bootstrap.php');
 
 class syntax_plugin_bootswrapper_thumbnail extends syntax_plugin_bootswrapper_bootstrap {
 
-    protected $pattern_start = '<thumbnail>';
+    protected $pattern_start = '<thumbnail.*?>(?=.*?</thumbnail>)';
     protected $pattern_end   = '</thumbnail>';
 
-    protected $template_start = '<div class="bs-wrap bs-wrap-thumbnail thumbnail">';
+    protected $template_start = '<div class="bs-wrap bs-wrap-thumbnail thumbnail %s" id="%s" style="%s">';
     protected $template_end   = '</div>';
 
     function getPType(){ return 'block'; }

--- a/syntax/tooltip.php
+++ b/syntax/tooltip.php
@@ -53,12 +53,14 @@ class syntax_plugin_bootswrapper_tooltip extends syntax_plugin_bootswrapper_boot
                     $placement = $attributes['placement'];
                     $title     = $attributes['title'];
                     $html      = $attributes['html'];
+                    $style = $this->getStylingAttributes($attributes);
 
                     if ($html) {
                       $title = hsc(p_render('xhtml',p_get_instructions($title), $info));
                     }
 
-                    $markup = sprintf('<span class="bs-wrap bs-wrap-tooltip" data-toggle="tooltip" data-html="%s" data-placement="%s" title="%s" style="border-bottom:1px dotted">', $html, $placement, $title);
+                    $markup = sprintf('<span class="bs-wrap bs-wrap-tooltip %s" id="%s" data-toggle="tooltip" data-html="%s" data-placement="%s" title="%s" style="border-bottom:1px dotted; %s">',
+                      $style['class'], $style['id'], $html, $placement, $title, $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;

--- a/syntax/well.php
+++ b/syntax/well.php
@@ -42,7 +42,10 @@ class syntax_plugin_bootswrapper_well extends syntax_plugin_bootswrapper_bootstr
                 case DOKU_LEXER_ENTER:
 
                     $size   = ($attributes['size']) ? 'well-'.$attributes['size'] : '';
-                    $markup = sprintf('<div class="bs-wrap bs-wrap-well well %s">', $size);
+                    $style = $this->getStylingAttributes($attributes);
+
+                    $markup = sprintf('<div class="bs-wrap bs-wrap-well well %s %s" id="%s" style="%s">',
+                      $size, $style['class'], $style['id'], $style['style']);
 
                     $renderer->doc .= $markup;
                     return true;


### PR DESCRIPTION
I've made it so you can add classes, set the id or set custom css for all attributes.
There is a new config option that must be toggled on for the styling to working.
If styling is disabled it won't be rendered and it will fail to check attributes as the tag would be invalid.

All components now have the more advanced pattern like `<tag.*?>(?=.*?</tag>)`
For basic components that don't override the render you have to add placeholders in the template.
For example: `<div class="bs-wrap bs-wrap-lead lead %s" id="%s" style="%s">`

Other components manually have to add the styling tags using the following code:
```php
$style = $this->getStylingAttributes($attributes);

 $markup = sprintf('<%s class="bs-wrap bs-wrap-label label label-%s %s" id="%s" style="%s">',
     $label_tag, $type, $style['class'], $style['id'], $style['style']);
```

Another example:
```php
//Use the ID from the component instead of styling for components that require a ID
//Because styling might be disabled and you'd still need the id
$markup = sprintf('<div class="bs-wrap bs-wrap-accordion panel-group %s" id="%s" style="%s">',
    $style['class'], $id, $style['style']);
```

### Preview
You can see and test it on my wiki
http://gameboxx.info/wiki/styling?purge=true